### PR TITLE
adds quevee action to deploy action

### DIFF
--- a/.github/workflows/deploy_crate.yml
+++ b/.github/workflows/deploy_crate.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           release_url: ${{ github.event.release.html_url }}
           artifacts_readme: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/README.md
-          artifacts_requirements: 
+          artifacts_requirements:
           artifacts_testing: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/.github/actions/run-lib-tests/action.yml
           artifacts_documentation: https://docs.rs/kuksa-rust-sdk/latest/kuksa_rust_sdk/, https://crates.io/crates/kuksa-rust-sdk
           artifacts_coding_guidelines: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/CONTRIBUTING.md
@@ -39,4 +39,4 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.quevee.outputs.manifest_file }}
-          tag: ${{ github.ref }}  
+          tag: ${{ github.ref }}

--- a/.github/workflows/deploy_crate.yml
+++ b/.github/workflows/deploy_crate.yml
@@ -21,3 +21,22 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_API_TOKEN }}
         run: cargo publish -p kuksa-rust-sdk
+
+      - name: Collect quality artifacts
+        uses: eclipse-dash/quevee@v1
+        id: quevee
+        with:
+          release_url: ${{ github.event.release.html_url }}
+          artifacts_readme: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/README.md
+          artifacts_requirements: 
+          artifacts_testing: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/.github/actions/run-lib-tests/action.yml
+          artifacts_documentation: https://docs.rs/kuksa-rust-sdk/latest/kuksa_rust_sdk/, https://crates.io/crates/kuksa-rust-sdk
+          artifacts_coding_guidelines: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/CONTRIBUTING.md
+          artifacts_release_process: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/RELEASE.md
+      - name: Upload quality manifest to release
+        uses: svenstaro/upload-release-action@v2
+        id: upload_manifest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.quevee.outputs.manifest_file }}
+          tag: ${{ github.ref }}  

--- a/.github/workflows/deploy_crate.yml
+++ b/.github/workflows/deploy_crate.yml
@@ -29,7 +29,7 @@ jobs:
           release_url: ${{ github.event.release.html_url }}
           artifacts_readme: README.md
           artifacts_requirements:
-          artifacts_testing: .github/actions/run-lib-tests/action.yml
+          artifacts_testing:
           artifacts_documentation: https://docs.rs/kuksa-rust-sdk/${{ github.event.release.tag_name }}, https://crates.io/crates/kuksa-rust-sdk/${{ github.event.release.tag_name }}, README.md
           artifacts_coding_guidelines: CONTRIBUTING.md
           artifacts_release_process: RELEASE.md

--- a/.github/workflows/deploy_crate.yml
+++ b/.github/workflows/deploy_crate.yml
@@ -27,12 +27,12 @@ jobs:
         id: quevee
         with:
           release_url: ${{ github.event.release.html_url }}
-          artifacts_readme: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/README.md
+          artifacts_readme: README.md
           artifacts_requirements:
-          artifacts_testing: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/.github/actions/run-lib-tests/action.yml
-          artifacts_documentation: https://docs.rs/kuksa-rust-sdk/latest/kuksa_rust_sdk/, https://crates.io/crates/kuksa-rust-sdk
-          artifacts_coding_guidelines: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/CONTRIBUTING.md
-          artifacts_release_process: https://github.com/eclipse-kuksa/kuksa-rust-sdk/blob/main/RELEASE.md
+          artifacts_testing: .github/actions/run-lib-tests/action.yml
+          artifacts_documentation: https://docs.rs/kuksa-rust-sdk/${{ github.event.release.tag_name }}, https://crates.io/crates/kuksa-rust-sdk/${{ github.event.release.tag_name }}, README.md
+          artifacts_coding_guidelines: CONTRIBUTING.md
+          artifacts_release_process: RELEASE.md
       - name: Upload quality manifest to release
         uses: svenstaro/upload-release-action@v2
         id: upload_manifest


### PR DESCRIPTION
The quevee action is developed by the Eclipse Foundation to track the different Eclipse SDV badges.

The badges would then be visible here: https://metrics.eclipse.org/projects/automotive.kuksa/#tabs-project_basics-5

For this to happen, the releases need a manifest file with further information for the tooling run by the Eclipse Foundation. 