### PR TITLE
Adding keywords and new crates.io automotive category to package metadata

### DIFF
--- a/databroker-examples/examples/kuksa_rust_sdk.rs
+++ b/databroker-examples/examples/kuksa_rust_sdk.rs
@@ -51,11 +51,11 @@ async fn execute_v2_calls(host: &'static str) {
                         let response = option.unwrap();
                         for entry_update in response.entries {
                             let datapoint = entry_update.1;
-                            println!("Vehicle.Speed: {:?}", datapoint);
+                            println!("Vehicle.Speed: {datapoint:?}");
                         }
                     }
                     Err(err) => {
-                        println!("Error: Could not receive response {:?}", err);
+                        println!("Error: Could not receive response {err:?}");
                     }
                 }
             });
@@ -90,7 +90,7 @@ async fn execute_v2_calls(host: &'static str) {
 
     match common::ClientTraitV2::get_value(&mut v2_client, "Vehicle.Speed".to_owned()).await {
         Ok(response) => {
-            println!("Got value for Vehicle.Speed: {:?}", response);
+            println!("Got value for Vehicle.Speed: {response:?}");
         }
         Err(err) => {
             println!(
@@ -113,11 +113,11 @@ async fn execute_v1_calls(host: &'static str) {
                         let response = option.unwrap();
                         for entry_update in response.updates {
                             let entry = entry_update.entry.unwrap();
-                            println!("Vehicle.Speed: {:?}", entry);
+                            println!("Vehicle.Speed: {entry:?}");
                         }
                     }
                     Err(err) => {
-                        println!("Error: Could not receive response {:?}", err);
+                        println!("Error: Could not receive response {err:?}");
                     }
                 }
             });
@@ -141,7 +141,7 @@ async fn execute_v1_calls(host: &'static str) {
             println!("Successfully set datapoints")
         }
         Err(err) => {
-            println!("Failed to set datapoints: {:?}", err)
+            println!("Failed to set datapoints: {err:?}")
         }
     }
 
@@ -152,10 +152,10 @@ async fn execute_v1_calls(host: &'static str) {
     .await
     {
         Ok(response) => {
-            println!("Got value for Vehicle.Speed: {:?}", response);
+            println!("Got value for Vehicle.Speed: {response:?}");
         }
         Err(err) => {
-            println!("Couldn't get value for Vehicle.Speed: {:?}", err)
+            println!("Couldn't get value for Vehicle.Speed: {err:?}")
         }
     }
 }
@@ -173,11 +173,11 @@ async fn execute_sdv_calls(host: &'static str) {
                     Ok(option) => {
                         let response = option.unwrap();
                         if let Some(speed) = response.fields.get("Vehicle.Speed") {
-                            println!("Vehicle.Speed: {:?}", speed);
+                            println!("Vehicle.Speed: {speed:?}");
                         };
                     }
                     Err(err) => {
-                        println!("Error: Could not receive response {:?}", err);
+                        println!("Error: Could not receive response {err:?}");
                     }
                 }
             });
@@ -201,7 +201,7 @@ async fn execute_sdv_calls(host: &'static str) {
             println!("Successfully set datapoints")
         }
         Err(err) => {
-            println!("Failed to set datapoints: {:?}", err)
+            println!("Failed to set datapoints: {err:?}")
         }
     }
 
@@ -212,10 +212,10 @@ async fn execute_sdv_calls(host: &'static str) {
     .await
     {
         Ok(response) => {
-            println!("Got value for Vehicle.Speed: {:?}", response);
+            println!("Got value for Vehicle.Speed: {response:?}");
         }
         Err(err) => {
-            println!("Failed to get value for Vehicle.Speed: {:?}", err)
+            println!("Failed to get value for Vehicle.Speed: {err:?}")
         }
     }
 }

--- a/databroker-examples/examples/kuksa_val_v2.rs
+++ b/databroker-examples/examples/kuksa_val_v2.rs
@@ -51,11 +51,11 @@ async fn sample_get_signal(client: &mut KuksaClientV2) {
                 println!("{}: {:?}", signal, datapoint.value);
             }
             None => {
-                println!("{} not set", signal);
+                println!("{signal} not set");
             }
         },
         Err(err) => {
-            println!("Error: Could not retrieve Signal {}: {}", signal, err);
+            println!("Error: Could not retrieve Signal {signal}: {err}");
         }
     }
 }
@@ -71,24 +71,24 @@ async fn sample_get_signals(client: &mut KuksaClientV2) {
             let speed = datapoints.first();
             match speed {
                 Some(value) => {
-                    println!("{}: {:?}", path_speed, value);
+                    println!("{path_speed}: {value:?}");
                 }
                 None => {
-                    println!("{} not set", path_speed);
+                    println!("{path_speed} not set");
                 }
             }
             let average_speed = datapoints.last();
             match average_speed {
                 Some(value) => {
-                    println!("{}: {:?}", path_average_speed, value);
+                    println!("{path_average_speed}: {value:?}");
                 }
                 None => {
-                    println!("{} not set", path_average_speed);
+                    println!("{path_average_speed} not set");
                 }
             }
         }
         Err(err) => {
-            println!("An error occurred while retrieving the Signals: {}", err);
+            println!("An error occurred while retrieving the Signals: {err}");
         }
     }
 }
@@ -101,10 +101,10 @@ async fn sample_publish_value(client: &mut KuksaClientV2) {
     let result = client.publish_value(signal.clone(), value).await;
     match result {
         Ok(_) => {
-            println!("{} published successfully", signal);
+            println!("{signal} published successfully");
         }
         Err(err) => {
-            println!("Error: Could not publish {}: {}", signal, err);
+            println!("Error: Could not publish {signal}: {err}");
         }
     }
 }
@@ -125,7 +125,7 @@ async fn sample_provide_actuation(client: &mut KuksaClientV2) {
                     println!("Successfully registered ProvideActuationRequest for Vehicle.ADAS.ABS.IsEnabled.");
                 }
                 Err(err) => {
-                    println!("Error: Could not send ProvideActuationRequest {:?}", err);
+                    println!("Error: Could not send ProvideActuationRequest {err:?}");
                 }
             }
 
@@ -140,18 +140,18 @@ async fn sample_provide_actuation(client: &mut KuksaClientV2) {
                             let actuate_requests = batch_actuate_stream_request.actuate_requests;
                             for actuate_request in actuate_requests {
                                 // execute actuate_requests
-                                println!("Received ActuateRequest: {:?}", actuate_request);
+                                println!("Received ActuateRequest: {actuate_request:?}");
                             }
                         }
                     }
                     Err(err) => {
-                        println!("Error: Could not receive response {:?}", err);
+                        println!("Error: Could not receive response {err:?}");
                     }
                 }
             });
         }
         Err(err) => {
-            println!("Could not open provider stream: {}", err);
+            println!("Could not open provider stream: {err}");
         }
     }
 }
@@ -171,15 +171,15 @@ async fn sample_subscribe(client: &mut KuksaClientV2) {
                         let response = option.unwrap();
                         if let Some(speed) = response.entries.get(&path_speed) {
                             // do something with speed
-                            println!("{}: {:?}", path_speed, speed);
+                            println!("{path_speed}: {speed:?}");
                         };
                         if let Some(average_speed) = response.entries.get(&path_avg_speed) {
                             // do something with average_speed
-                            println!("{}: {:?}", path_avg_speed, average_speed);
+                            println!("{path_avg_speed}: {average_speed:?}");
                         };
                     }
                     Err(err) => {
-                        println!("Error: Could not receive response {:?}", err);
+                        println!("Error: Could not receive response {err:?}");
                     }
                 };
             });
@@ -211,29 +211,29 @@ async fn sample_subscribe_by_id(client: &mut KuksaClientV2) {
                                     response.entries.get(path_ids_map.get(&path_speed).unwrap())
                                 {
                                     // do something with speed
-                                    println!("{}: {:?}", path_speed, speed);
+                                    println!("{path_speed}: {speed:?}");
                                 };
                                 if let Some(average_speed) = response
                                     .entries
                                     .get(path_ids_map.get(&path_avg_speed).unwrap())
                                 {
                                     // do something with average_speed
-                                    println!("{}: {:?}", path_avg_speed, average_speed);
+                                    println!("{path_avg_speed}: {average_speed:?}");
                                 };
                             }
                             Err(err) => {
-                                println!("Error: Could not receive response: {:?}", err);
+                                println!("Error: Could not receive response: {err:?}");
                             }
                         };
                     });
                 }
                 Err(err) => {
-                    println!("Error subscribing to ids: {:?}", err);
+                    println!("Error subscribing to ids: {err:?}");
                 }
             }
         }
         Err(err) => {
-            println!("Error: Could not resolve ids for path: {:?}", err);
+            println!("Error: Could not resolve ids for path: {err:?}");
         }
     }
 }
@@ -247,11 +247,11 @@ async fn sample_list_metadata(client: &mut KuksaClientV2) {
         Ok(metadatas) => {
             for metadata in metadatas {
                 // do something with metadata
-                println!("Received metadata: {:?}", metadata);
+                println!("Received metadata: {metadata:?}");
             }
         }
         Err(err) => {
-            println!("Error: Could not retrieve Metadata: {:?}", err);
+            println!("Error: Could not retrieve Metadata: {err:?}");
         }
     }
 }
@@ -261,10 +261,10 @@ async fn sample_server_info(client: &mut KuksaClientV2) {
     match result {
         Ok(server_info) => {
             // do something with ServerInfo
-            println!("Received ServerInfo: {:?}", server_info);
+            println!("Received ServerInfo: {server_info:?}");
         }
         Err(err) => {
-            println!("Error: Could not retrieve ServerInfo: {:?}", err);
+            println!("Error: Could not retrieve ServerInfo: {err:?}");
         }
     }
 }

--- a/databroker-examples/examples/slow_subscriber.rs
+++ b/databroker-examples/examples/slow_subscriber.rs
@@ -30,18 +30,18 @@ async fn main() {
     // Subscribe to paths
     let mut stream = client.subscribe(paths.clone()).await.unwrap();
 
-    println!("Subscribed to {:?}", paths);
+    println!("Subscribed to {paths:?}");
 
     loop {
         match stream.message().await {
             Ok(msg) => {
-                println!("Got message, will wait 5 seconds: {:?}", msg);
+                println!("Got message, will wait 5 seconds: {msg:?}");
                 // Simulate slow processing by sleeping
                 sleep(Duration::from_secs(1)).await;
                 thread::sleep(Duration::from_secs(5));
             }
             Err(e) => {
-                println!("Error while receiving message: {:?}", e);
+                println!("Error while receiving message: {e:?}");
                 break; // Exit loop on error
             }
         }

--- a/kuksa-rust-sdk/Cargo.toml
+++ b/kuksa-rust-sdk/Cargo.toml
@@ -8,6 +8,8 @@ description = "The Rust SDK for the Eclipse KUKSA Databroker."
 homepage = "https://eclipse-kuksa.github.io/kuksa-website/"
 repository = "https://github.com/eclipse-kuksa/kuksa-rust-sdk"
 readme = "../README.md"
+keywords = ["kuksa", "sdk", "sdv", "automotive", "eclipse"]
+categories = ["automotive"]
 
 [dependencies]
 futures-core = "0.3.31"

--- a/kuksa-rust-sdk/src/kuksa/common/conversion.rs
+++ b/kuksa-rust-sdk/src/kuksa/common/conversion.rs
@@ -1715,8 +1715,7 @@ mod tests {
             let result = input.clone().convert_to_v1();
             assert_eq!(
                 result, *expected,
-                "Test failed for input: {:?}\nExpected: {:?}\nGot: {:?}",
-                input, expected, result
+                "Test failed for input: {input:?}\nExpected: {expected:?}\nGot: {result:?}"
             );
         }
     }

--- a/kuksa-rust-sdk/src/kuksa/common/mod.rs
+++ b/kuksa-rust-sdk/src/kuksa/common/mod.rs
@@ -317,7 +317,7 @@ pub fn to_uri(uri: impl AsRef<str>) -> Result<Uri, String> {
 
 impl Client {
     pub fn new(uri: Uri) -> Self {
-        info!("Creating client with URI: {}", uri);
+        info!("Creating client with URI: {uri}");
         Client {
             uri,
             token: None,

--- a/kuksa-rust-sdk/src/kuksa/val/v2/mod.rs
+++ b/kuksa-rust-sdk/src/kuksa/val/v2/mod.rs
@@ -1446,7 +1446,7 @@ mod tests {
             ReadWrite => "actuate-provide-all.token",
             Read => "read-all.token",
         };
-        let file_path = format!("../submodules/kuksa-common/jwt/{}", file_name);
+        let file_path = format!("../submodules/kuksa-common/jwt/{file_name}");
         fs::read_to_string(file_path).expect("Could not read file")
     }
 


### PR DESCRIPTION
We never head any keywords, and more importantly there is an "automotive" category in crates.io now:

https://github.com/rust-lang/crates.io/pull/11645

This PR tries to add the relevant metadata

It hast has two commits, because clippy rules on string formatting evolved, so quite a bit of unrelated things needed to be updated to get a green CI run.

