### PR TITLE
Fixes Clippy Warning

### DIFF
--- a/kuksa-rust-sdk/src/kuksa/val/v2/mod.rs
+++ b/kuksa-rust-sdk/src/kuksa/val/v2/mod.rs
@@ -632,8 +632,8 @@ mod tests {
 
             let mut client = Self::new(Uri::from_static(host));
 
-            if token_type.is_some() {
-                let jwt = read_jwt(token_type.unwrap());
+            if let Some(token) = token_type {
+                let jwt = read_jwt(token);
                 client
                     .basic_client
                     .set_access_token(jwt)


### PR DESCRIPTION
This PR changes a check for Some() with a  following unwrap to if let Some(x) = y.

The problem is also part of #16 and might be introduced through a newer version of the Rust toolchain. 